### PR TITLE
Gcloudを入れる。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian
 RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip curl ruby mariadb-client -y
+RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.73.zip && unzip google*.zip && rm *.zip
 RUN curl https://sdk.cloud.google.com | bash
 RUN pip install mysqlclient
-ENV PATH=$PATH:/root/google-cloud-sdk/bin/
+ENV PATH=$PATH:/google_appengine:/root/google-cloud-sdk/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian
-RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip ruby mariadb-client -y
+RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip curl ruby mariadb-client -y
 RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.73.zip && unzip google*.zip && rm *.zip
+RUN curl https://sdk.cloud.google.com | bash
 RUN pip install mysqlclient
 ENV PATH=$PATH:/google_appengine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian
 RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip curl ruby mariadb-client -y
 RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.73.zip && unzip google*.zip && rm *.zip
-RUN curl https://sdk.cloud.google.com | bash
+RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-245.0.0-linux-x86_64.tar.gz && tar -xzf google*.tar.gz && rm *.gz
 RUN pip install mysqlclient
-ENV PATH=$PATH:/google_appengine:/root/google-cloud-sdk/bin
+ENV PATH=$PATH:/google_appengine:/google-cloud-sdk/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM debian
 RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip curl ruby mariadb-client -y
-RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.73.zip && unzip google*.zip && rm *.zip
 RUN curl https://sdk.cloud.google.com | bash
 RUN pip install mysqlclient
-ENV PATH=$PATH:/google_appengine
+ENV PATH=$PATH:/root/google-cloud-sdk/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian
-RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip curl ruby mariadb-client -y
+RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip ruby mariadb-client -y
 RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.73.zip && unzip google*.zip && rm *.zip
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-245.0.0-linux-x86_64.tar.gz && tar -xzf google*.tar.gz && rm *.gz
 RUN pip install mysqlclient


### PR DESCRIPTION
https://github.com/ubiregiinc/stockscan-server/pull/336

のために、docker image内にGcloudをインストールします。
~スタンドアロン版google appengineは要らなくなるので削除します。~

stockscan-server側のテストが落ちるのでもうすこしみます

また、docker hubでは この差分をv2として登録しました。

https://hub.docker.com/layers/ubiregiinc/ubi-gae-python-base/v2/images/sha256-aa690a05989ccb7bbb22a290bf3bd6bd493e26bec30c0ac4c9c79e03154c7dc8