### PR TITLE
スタンドアロン版google appengine sdkを削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM debian
 RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip ruby mariadb-client -y
-RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.73.zip && unzip google*.zip && rm *.zip
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-245.0.0-linux-x86_64.tar.gz && tar -xzf google*.tar.gz && rm *.gz
 RUN pip install mysqlclient
-ENV PATH=$PATH:/google_appengine:/google-cloud-sdk/bin
+ENV PATH=$PATH:/google-cloud-sdk/bin


### PR DESCRIPTION
appengine-sdks/featured/google_appengine を削除しました。

このDockerfileはv3で登録しました。

https://hub.docker.com/layers/ubiregiinc/ubi-gae-python-base/v3/images/sha256-b587de7aee7f621cf56b94b65238c212d0910e29a072556519895f99ccb90b99