### PR TITLE
app-engine-pythonのコンポーネントを追加する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,4 @@ RUN apt update && apt install python wget libmariadbclient-dev python-pip unzip 
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-245.0.0-linux-x86_64.tar.gz && tar -xzf google*.tar.gz && rm *.gz
 RUN pip install mysqlclient
 ENV PATH=$PATH:/google-cloud-sdk/bin
+RUN gcloud components install app-engine-python


### PR DESCRIPTION
https://github.com/ubiregiinc/ubi-gae-python-base/pull/3

gcloudはこのままだと最低限のコンポーネントしか入っていない。
pythonアプリを `gcloud app deploy` でデプロイする際必要なコンポーネントを入れないといけなかった。
stockscan のtest実行時に使うパッケージもこの追加コンポーネント内に入っているので、予め入れておきたい。

詳しくはこちら
https://cloud.google.com/sdk/docs/components?hl=ja

このDockerfileは前のを上書きしてv3で登録しました。

https://hub.docker.com/layers/ubiregiinc/ubi-gae-python-base/v3/images/sha256-64d96c7290b60ea9f0a0b3c87a7179d9c793d838a67f4c1329b4f5920f723e80